### PR TITLE
feat: Update Cloudflare zone resource to use `name` instead of `zone`

### DIFF
--- a/modules/cloudflare-zone/main.tf
+++ b/modules/cloudflare-zone/main.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_zone" "this" {
   for_each   = local.domains_to_create
   account_id = var.cloudflare_account_id
-  zone       = each.value
+  name       = each.value
 }

--- a/modules/cloudflare-zone/versions.tf
+++ b/modules/cloudflare-zone/versions.tf
@@ -3,7 +3,8 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }
+


### PR DESCRIPTION
Upgrade Cloudflare provider to version 5.0

The changes in this commit update the Cloudflare zone resource to use the `name` attribute instead of the `zone` attribute, which is more accurate and consistent with the Cloudflare provider documentation. Additionally, the Terraform provider version for Cloudflare is upgraded to version 5.0 to ensure compatibility with the latest features and bug fixes.