### PR TITLE
feat: Update Cloudflare zone resource to use `account` instead of `account_id`

### DIFF
--- a/modules/cloudflare-zone/main.tf
+++ b/modules/cloudflare-zone/main.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_zone" "this" {
   for_each   = local.domains_to_create
-  account_id = var.cloudflare_account_id
+  account = var.cloudflare_account_id
   name       = each.value
 }


### PR DESCRIPTION
The `account_id` argument in the `cloudflare_zone` resource has been deprecated and replaced with the `account` argument. This commit updates the resource to use the new `account` argument instead.