### PR TITLE
fix: Remove unused `cloudflare_zone_plan` output

### DIFF
--- a/modules/cloudflare-zone/outputs.tf
+++ b/modules/cloudflare-zone/outputs.tf
@@ -13,11 +13,6 @@ output "cloudflare_zone_name_servers" {
   description = "the zone name servers"
 }
 
-output "cloudflare_zone_plan" {
-  value       = !local.is_enabled ? {} : { for zone in cloudflare_zone.this : zone.plan => zone.plan }
-  description = "the zone plans"
-}
-
 output "cloudflare_zone_plan_id" {
   value       = !local.is_enabled ? {} : { for zone in cloudflare_zone.this : zone.id => zone.id }
   description = "the zone plan ids"


### PR DESCRIPTION
The `cloudflare_zone_plan` output was not being used, so it has been removed to simplify the module's outputs.